### PR TITLE
Add dark/light mode toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+<html lang="{{ page.lang | default: site.lang | default: "en" }}" data-theme="{{ site.style }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,6 +11,8 @@
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
             max-width: 800px;
             margin: 0 auto;
+            background-color: var(--background-color);
+            color: var(--text-color);
         }
         .site-header {
             text-align: center;
@@ -27,6 +29,9 @@
         }
         nav {
             margin-bottom: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
         }
         nav a {
             color: var(--text-color);
@@ -46,7 +51,28 @@
             margin: 0 auto;
             max-width: 600px;
         }
+        .theme-toggle {
+            margin-left: 15px;
+            padding: 5px 10px;
+            background-color: var(--text-color);
+            color: var(--background-color);
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 12px;
+            font-family: inherit;
+        }
+        .theme-toggle:hover {
+            opacity: 0.9;
+        }
     </style>
+    <script>
+        // Set the initial theme
+        (function() {
+            const savedTheme = localStorage.getItem('theme') || '{{ site.style }}';
+            document.documentElement.setAttribute('data-theme', savedTheme);
+        })();
+    </script>
 </head>
 <body>
     <header class="site-header">
@@ -54,10 +80,32 @@
         <nav>
             <a href="/about">About</a>
             <a href="/research">Research</a>
+            <button id="theme-toggle" class="theme-toggle">dark</button>
         </nav>
     </header>
     <main>
         {{ content }}
     </main>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const themeToggle = document.getElementById('theme-toggle');
+            const currentTheme = localStorage.getItem('theme') || '{{ site.style }}';
+            
+            // Set initial button text
+            themeToggle.textContent = currentTheme === 'dark' ? 'dark' : 'light';
+            
+            themeToggle.addEventListener('click', function() {
+                const currentTheme = document.documentElement.getAttribute('data-theme');
+                const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+                
+                // Update theme
+                document.documentElement.setAttribute('data-theme', newTheme);
+                localStorage.setItem('theme', newTheme);
+                
+                // Update button text
+                themeToggle.textContent = newTheme;
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds a dark/light mode toggle button in the navigation bar
- Implements theme switching functionality with local storage for persistence
- Provides visual indicator of current theme (button shows 'dark' or 'light')

## Test plan
- Verify button appears in the navigation bar
- Confirm theme changes when toggling between modes
- Check that preference is remembered between page reloads