### PR TITLE
Improve content breathing room and responsive spacing

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -36,7 +36,7 @@ body {
 }
 
 .site-container {
-  width: 75%;
+  width: 90%;
   max-width: 1100px;
   margin: 0 auto;
 }
@@ -448,9 +448,23 @@ img[src*='#center'] {
 /*
  * Responsive adjustments
  */
+@media (max-width: 768px) {
+  .site-container {
+    width: 95%;
+  }
+
+  body {
+    padding: 28px;
+  }
+}
+
 @media (max-width: 480px) {
   body {
-    padding: 32px 16px 16px;
+    padding: 20px;
+  }
+
+  .site-container {
+    width: 100%;
   }
 
   .site-header {


### PR DESCRIPTION
- Increase desktop content width from 75% to 90% for more readable line lengths
- Keep borders at subtle 1px width
- Add tablet breakpoint (768px) with 95% width and 28px padding
- Improve mobile spacing: 100% width with 20px padding for better breathing room
- Ensure content has appropriate space on all device sizes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase base container width and add tablet/mobile spacing adjustments.
> 
> - **Styles** (`_sass/base.scss`):
>   - **Layout**: `.site-container` width to `90%` (was `75%`).
>   - **Responsive**:
>     - `@media (max-width: 768px)`: `.site-container` `width: 95%`; `body` `padding: 28px`.
>     - `@media (max-width: 480px)`: `body` `padding: 20px`; `.site-container` `width: 100%`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 947d8ab16df5780e17d29db5ca7db9073a71557d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->